### PR TITLE
Document handling of `node:// URI conversion requires a context node to be passed`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,54 @@ composer require carbon/link --no-update
 
 The `--no-update` command prevent the automatic update of the dependencies. After the package was added to your theme `composer.json`, go back to the root of the Neos installation and run `composer update`. Et voilà! Your desired package is now installed correctly.
 
+## Questions
+
+### What is the `node:// URI conversion requires a context node to be passed` error about?
+
+`Carbon.Link:Link` and the internal `Neos.Neos:NodeUri` make use of the commonly available `documentNode` context variable to obtain context information such as language and workspace and to calculate relative links. This variable is provided by default in the \Neos\Neos\View\FusionView, but not, for example, in the \Neos\Fusion\View\FusionView, which is mainly used for Model View Controller applications. Make sure that you manually retrieve the document node and add it to the view, e.g.
+
+```
+<?php
+
+class ArticlesController extends ActionController
+{
+    ...
+
+    public function listAction(): void
+    {
+        $workspaceName = 'live';
+        $language = 'de';
+
+        $contextProperties = [
+            'workspaceName' => $workspaceName,
+            'invisibleContentShown' => false,
+            'inaccessibleContentShown' => false,
+            'dimensions' => [
+                'language' => [$language]
+            ],
+            'targetDimensions' => [
+                'language' => $language
+            ]
+        ];
+
+        $currentDomain = $this->domainRepository->findOneByActiveRequest();
+
+        if ($currentDomain !== null) {
+            $contextProperties['currentSite'] = $currentDomain->getSite();
+            $contextProperties['currentDomain'] = $currentDomain;
+        } else {
+            $contextProperties['currentSite'] = $this->siteRepository->findFirstOnline();
+        }
+
+        $contentContext = $this->contextFactory->create($contextProperties);
+
+        $site = $contentContext->getCurrentSiteNode();
+
+        $this->view->assign('documentNode', $site);
+    }
+}
+```
+
 ## License
 
 Licensed under MIT, see [LICENSE](LICENSE)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The `--no-update` command prevent the automatic update of the dependencies. Afte
 
 `Carbon.Link:Link` and the internal `Neos.Neos:NodeUri` make use of the commonly available `documentNode` context variable to obtain context information such as language and workspace and to calculate relative links. This variable is provided by default in the \Neos\Neos\View\FusionView, but not, for example, in the \Neos\Fusion\View\FusionView, which is mainly used for Model View Controller applications. Make sure that you manually retrieve the document node and add it to the view, e.g.
 
-```
+```php
 <?php
 
 class ArticlesController extends ActionController
@@ -35,7 +35,7 @@ class ArticlesController extends ActionController
     public function listAction(): void
     {
         $workspaceName = 'live';
-        $language = 'de';
+        $language = 'en';
 
         $contextProperties = [
             'workspaceName' => $workspaceName,

--- a/Resources/Private/Fusion/Link/Asset.fusion
+++ b/Resources/Private/Fusion/Link/Asset.fusion
@@ -1,6 +1,6 @@
 prototype(Carbon.Link:Asset) < prototype(Neos.Fusion:Case) {
     link = ${link ? link : false}
-    asset = ${asset ? asset : link ? Neos.Link.convertUriToObject(link, node) : false}
+    asset = ${asset ? asset : link ? Neos.Link.convertUriToObject(link, documentNode) : false}
     @context.asset = ${this.asset}
     @ignoreProperties = ${['link', 'asset']}
 

--- a/Resources/Private/Fusion/Link/Rel.fusion
+++ b/Resources/Private/Fusion/Link/Rel.fusion
@@ -10,7 +10,7 @@ prototype(Carbon.Link:Rel) < prototype(Neos.Fusion:Value) {
     value = Neos.Fusion:Case {
         @context.linkType = Carbon.Link:Type
         inBackend {
-            condition = ${node.context.inBackend}
+            condition = ${documentNode.context.inBackend}
             renderer = false
             @position = 'start 1'
         }

--- a/Resources/Private/Fusion/Link/TagName.fusion
+++ b/Resources/Private/Fusion/Link/TagName.fusion
@@ -5,5 +5,5 @@ prototype(Carbon.Link:TagName) < prototype(Neos.Fusion:Value) {
     backendLink = ${backendLink ? backendLink : false}
     @context.link = ${this.link}
     valid = Carbon.Link:Valid
-    value = ${this.link && this.valid && (node.context.live || this.backendLink) ? this.linkTagName : this.defaultTagName}
+    value = ${this.link && this.valid && (documentNode.context.live || this.backendLink) ? this.linkTagName : this.defaultTagName}
 }

--- a/Resources/Private/Fusion/Link/Target.fusion
+++ b/Resources/Private/Fusion/Link/Target.fusion
@@ -21,7 +21,7 @@ prototype(Carbon.Link:Target) < prototype(Neos.Fusion:Value) {
                     }
                     isNode {
                         condition = ${String.startsWith(link, 'node://')}
-                        renderer = ${q(Neos.Link.convertUriToObject(link, node)).property('target')}
+                        renderer = ${q(Neos.Link.convertUriToObject(link, documentNode)).property('target')}
                     }
                 }
                 object = ${String.startsWith(this.assetString, 'asset://') ? Neos.Link.convertUriToObject(this.assetString) : null}

--- a/Resources/Private/Fusion/Link/Type.fusion
+++ b/Resources/Private/Fusion/Link/Type.fusion
@@ -3,7 +3,7 @@ prototype(Carbon.Link:Type) < prototype(Neos.Fusion:Case) {
 
     @context {
         scheme = ${Neos.Link.getScheme(this.link)}
-        node = ${Neos.Link.convertUriToObject(this.link, node)}
+        node = ${Neos.Link.convertUriToObject(this.link, documentNode)}
         link = ${this.link}
     }
 

--- a/Resources/Private/Fusion/Link/URI.fusion
+++ b/Resources/Private/Fusion/Link/URI.fusion
@@ -10,13 +10,13 @@ prototype(Carbon.Link:URI) < prototype(Neos.Fusion:Value) {
     value = Neos.Fusion:Case {
         @context.linkType = Carbon.Link:Type
         isBackend {
-            condition = ${node.context.inBackend && !backendLink ? true : false}
+            condition = ${documentNode.context.inBackend && !backendLink ? true : false}
             renderer = '#'
         }
         isNode {
             condition = ${linkType == 'node'}
             renderer = Neos.Neos:NodeUri {
-                nodeObject = ${Neos.Link.convertUriToObject(link, node)}
+                nodeObject = ${Neos.Link.convertUriToObject(link, documentNode)}
                 node = ${q(this.nodeObject).closest(Configuration.setting('Carbon.Link.instanceOfDocument')).get(0)}
                 section = ${q(this.nodeObject).is(Configuration.setting('Carbon.Link.instanceOfDocument')) ? false : Configuration.setting('Carbon.Link.prependIdentifier') + nodeObject.identifier}
             }

--- a/Resources/Private/Fusion/Link/Valid.fusion
+++ b/Resources/Private/Fusion/Link/Valid.fusion
@@ -25,7 +25,7 @@ prototype(Carbon.Link:Valid) < prototype(Neos.Fusion:Value) {
 
 prototype(Carbon.Link:ValidOrBackend) < prototype(Carbon.Link:Valid) {
     value.isBackend {
-        condition = ${node.context.inBackend}
+        condition = ${documentNode.context.inBackend}
         renderer = true
         @position = 'start'
     }


### PR DESCRIPTION
Hi Jon,

this patch is to give some advice to future users of this package which might run into the `node:// URI conversion requires a context node to be passed` error: I added a note in the README.md and took the opportunity to streamline the use of the context variables `documentNode` and `node` where maybe only one is required. I opted for `documentNode` which is also the default context variable of the internally used `Neos.Neos:NodeUri`.

Greetings
Alex