### PR TITLE
Task: Neos 9 Compatibility (breaking!)

### DIFF
--- a/Resources/Private/Fusion/Link/Attributes.fusion
+++ b/Resources/Private/Fusion/Link/Attributes.fusion
@@ -1,4 +1,4 @@
-prototype(Carbon.Link:Attributes) < prototype(Neos.Fusion:Attributes) {
+prototype(Carbon.Link:Attributes) < prototype(Neos.Fusion:DataStructure) {
     link = ${link ? link : false}
     backendLink = ${backendLink ? backendLink : false}
     additionalClass = ${additionalClass ? additionalClass : false}

--- a/Resources/Private/Fusion/Link/Class.fusion
+++ b/Resources/Private/Fusion/Link/Class.fusion
@@ -1,4 +1,4 @@
-prototype(Carbon.Link:Class) < prototype(Neos.Fusion:RawArray) {
+prototype(Carbon.Link:Class) < prototype(Neos.Fusion:DataStructure) {
     link = ${link ? link : false}
 
     @context.link = ${this.link}

--- a/Resources/Private/Fusion/Link/Link.fusion
+++ b/Resources/Private/Fusion/Link/Link.fusion
@@ -1,6 +1,6 @@
 prototype(Carbon.Link:Link) < prototype(Neos.Fusion:Tag) {
     node = null
-    link = ${this.node ? 'node://' + this.node.identifier : link ? link : false}
+    link = ${this.node ? 'node://' + this.node.nodeAggregateId.value : link ? link : false}
     backendLink = false
     additionalClass = null
     title = null

--- a/Resources/Private/Fusion/Link/Rel.fusion
+++ b/Resources/Private/Fusion/Link/Rel.fusion
@@ -10,7 +10,7 @@ prototype(Carbon.Link:Rel) < prototype(Neos.Fusion:Value) {
     value = Neos.Fusion:Case {
         @context.linkType = Carbon.Link:Type
         inBackend {
-            condition = ${documentNode.context.inBackend}
+            condition = ${renderingMode.isEdit}
             renderer = false
             @position = 'start 1'
         }

--- a/Resources/Private/Fusion/Link/TagName.fusion
+++ b/Resources/Private/Fusion/Link/TagName.fusion
@@ -5,5 +5,5 @@ prototype(Carbon.Link:TagName) < prototype(Neos.Fusion:Value) {
     backendLink = ${backendLink ? backendLink : false}
     @context.link = ${this.link}
     valid = Carbon.Link:Valid
-    value = ${this.link && this.valid && (documentNode.context.live || this.backendLink) ? this.linkTagName : this.defaultTagName}
+    value = ${this.link && this.valid && (!renderingMode.isEdit || this.backendLink) ? this.linkTagName : this.defaultTagName}
 }

--- a/Resources/Private/Fusion/Link/URI.fusion
+++ b/Resources/Private/Fusion/Link/URI.fusion
@@ -10,7 +10,7 @@ prototype(Carbon.Link:URI) < prototype(Neos.Fusion:Value) {
     value = Neos.Fusion:Case {
         @context.linkType = Carbon.Link:Type
         isBackend {
-            condition = ${documentNode.context.inBackend && !backendLink ? true : false}
+            condition = ${renderingMode.isEdit && !backendLink ? true : false}
             renderer = '#'
         }
         isNode {
@@ -18,7 +18,7 @@ prototype(Carbon.Link:URI) < prototype(Neos.Fusion:Value) {
             renderer = Neos.Neos:NodeUri {
                 nodeObject = ${Neos.Link.convertUriToObject(link, documentNode)}
                 node = ${q(this.nodeObject).closest(Configuration.setting('Carbon.Link.instanceOfDocument')).get(0)}
-                section = ${q(this.nodeObject).is(Configuration.setting('Carbon.Link.instanceOfDocument')) ? false : Configuration.setting('Carbon.Link.prependIdentifier') + nodeObject.identifier}
+                section = ${q(this.nodeObject).is(Configuration.setting('Carbon.Link.instanceOfDocument')) ? false : Configuration.setting('Carbon.Link.prependIdentifier') + nodeObject.nodeAggregateId.value}
             }
         }
         isAssetOrExternal {

--- a/Resources/Private/Fusion/Link/Valid.fusion
+++ b/Resources/Private/Fusion/Link/Valid.fusion
@@ -25,7 +25,7 @@ prototype(Carbon.Link:Valid) < prototype(Neos.Fusion:Value) {
 
 prototype(Carbon.Link:ValidOrBackend) < prototype(Carbon.Link:Valid) {
     value.isBackend {
-        condition = ${documentNode.context.inBackend}
+        condition = ${renderingMode.isEdit}
         renderer = true
         @position = 'start'
     }

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "keywords": ["flow", "neos", "fusion", "helper", "link", "carbon"],
     "require": {
-        "neos/neos": "^5.3 || ^7.0 || ^8.0",
+        "neos/neos": "^5.3 || ^7.0 || ^8.0 || ^9.0 || dev-master",
         "carbon/eel": "^1.2 || ^2.0"
     },
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "keywords": ["flow", "neos", "fusion", "helper", "link", "carbon"],
     "require": {
-        "neos/neos": "^5.3 || ^7.0 || ^8.0 || ^9.0 || dev-master",
+        "neos/neos": "^9.0",
         "carbon/eel": "^1.2 || ^2.0"
     },
     "authors": [


### PR DESCRIPTION
This PR makes the package compatible for Neos 9 and removes compatibility for all Neos versions below 9.0

Changes:
- set requirement for `neos/neos`  as `^9.0`
- change `Neos.Fusion:Attributes` to `Neos.Fusion:DataStructure` -> `Neos.Fusion:Attributes` is deprecated since Neos 5.0 and will be removed with Neos 9.0
- change `Neos.Fusion:RawArray` to `Neos.Fusion:DataStructure` -> `Neos.Fusion:RawArray` is deprecated since Neos 4.2 and will be removed with Neos 9.0
- replace `node.identifier` with `node.nodeAggregateId.value`
- replace `documentNode.context.inBackend` with `renderingMode.isEdit`
